### PR TITLE
Add ignore_errors config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Parameter                   | Description
 **poll_state_delay**    | Time between polling for the garage door's state (leave blank to disable state polling)
 **device_number**	| Door number (0-2). Defaults to 0
 **garage_number**	| Garage number (1-3). Defaults to 1
-**ignore_errors**	| Causes the plugin to replace 'STOPPED' status with 'CLOSED' (defaults to false)
+**ignore_errors**	| true/false. Causes the plugin to replace 'STOPPED' status with 'CLOSED' (defaults to false)
 
 ## Note:
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ Parameter                   | Description
 ## Note:
 
 I was unable to get proper response from the API when I used a secondary (invited) Aladdin Connect credentials. As a workaround, I had to use the primary login credentials instead. I advise you do the same.
+
+The `ignore_errors` config option is in place to prevent false OPEN events from occuring if the aladdin connect API fails to respond. Events where STOPPED is replaced with CLOSED are logged, but consider this a word of caution that setting this option to true ignores errors and could incorrectly report your garage door as CLOSED when it is not.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Parameter                   | Description
 **poll_state_delay**    | Time between polling for the garage door's state (leave blank to disable state polling)
 **device_number**	| Door number (0-2). Defaults to 0
 **garage_number**	| Garage number (1-3). Defaults to 1
+**ignore_errors**	| Causes the plugin to replace 'STOPPED' status with 'CLOSED' (defaults to false)
 
 ## Note:
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class AladdinConnectGarageDoorOpener {
     this.pollStateDelay = config.poll_state_delay || 0;
     this.deviceNumber = config.device_number || 0;
     this.garageNumber = config.garage_number || 1;
+    this.ignoreErrors = config.ignore_errors || false;
   }
 
   getServices () {
@@ -98,8 +99,9 @@ class AladdinConnectGarageDoorOpener {
       accessory.username, accessory.password, 
       'status', 
       function (state) {
-        accessory.log('State of ' + accessory.name + ' is: ' + state);
-        callback(null, Characteristic.CurrentDoorState[state]);
+        var currentState = accessory.ignoreErrors && state === 'STOPPED' ? 'CLOSED' : state;
+        accessory.log('State of ' + accessory.name + ' is: ' + state + ' (sent ' + currentState + ')');
+        callback(null, Characteristic.CurrentDoorState[currentState], 'getState');
         if (accessory.pollStateDelay > 0) {
             accessory.pollState();
         }


### PR DESCRIPTION
Don't know about you, but I often get notifications that my garage door has opened only to find out the Aladdin Connect server is hiccuping and giving a 403 error. STOPPED (which is a valid state) gets sent, but the Home App says OPEN.

This PR adds a config option to prevent this behavior by sending 'CLOSED' instead of 'STOPPED'.
Logs are adjusted so these events can be tracked.

Added a note to README.md to use this config option with caution.