### PR TITLE
log polling option, Homebridge-config-ui-x schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Parameter                   | Description
 **device_number**	| Door number (0-2). Defaults to 0
 **garage_number**	| Garage number (1-3). Defaults to 1
 **ignore_errors**	| true/false. Causes the plugin to replace 'STOPPED' status with 'CLOSED' (defaults to false)
+**allow_debug**	| true/false. Dumps a lot of debug info to stdout. (defaults to false)
 
 ## Note:
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Parameter                   | Description
 **device_number**	| Door number (0-2). Defaults to 0
 **garage_number**	| Garage number (1-3). Defaults to 1
 **ignore_errors**	| true/false. Causes the plugin to replace 'STOPPED' status with 'CLOSED' (defaults to false)
+**log_polling** | true/false. Poll logs only show on error; Set to true to log every poll (defaults to false)
 **allow_debug**	| true/false. Dumps a lot of debug info to stdout. (defaults to false)
 
 ## Note:

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,101 @@
+{
+  "pluginAlias": "AladdinConnectGarageDoorOpener",
+  "pluginType": "accessory",
+  "singular": false,
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "type": "string",
+        "default": "Garage Door",
+        "required": true
+      },
+      "username": {
+        "title": "User Name/Email Address",
+        "type": "string",
+        "required": true
+      },
+      "password": {
+        "title": "Password",
+        "type": "string",
+        "required": true,
+        "options": {
+          "hidden": true
+        }
+      },
+      "status_update_delay": {
+        "title": "Status Update Delay",
+        "type": "string",
+        "default": "15",
+        "placeholder": "# of seconds to close",
+        "required": true
+      },
+      "poll_state_delay": {
+        "title": "Enable Polling (in seconds)",
+        "type": "integer",
+        "placeholder": "# of seconds"
+      },
+      "device_number": {
+        "title": "Device Number",
+        "type": "integer",
+        "placeholder": "0"
+      },
+      "garage_number": {
+        "title": "Garage Number",
+        "type": "integer",
+        "placeholder": "1"
+      },
+      "ignore_errors": {
+        "title": "Ignore Errors",
+        "type": "boolean"
+      },
+      "log_polling": {
+        "title": "Log Polling",
+        "type": "boolean"
+      },
+      "allow_debug": {
+        "title": "Allow Debug Logs",
+        "type": "boolean"
+      }
+    }
+  },
+  "form": [
+    "name",
+    "username",
+    "password",
+    {
+      "type": "fieldset",
+      "expandable": true,
+      "title": "Polling Settings",
+      "description": "Options for polling Garage Door when Home app is closed",
+      "items": [
+        "poll_state_delay",
+        "log_polling"
+      ]
+    },
+    {
+      "type": "fieldset",
+      "expandable": true,
+      "title": "Garage Door Settings",
+      "description": "Options for time to close and multiple garage door setup",
+      "items": [
+        "status_update_delay",
+        "device_number",
+        "garage_number"
+
+      ]
+    },
+    {
+      "type": "fieldset",
+      "expandable": true,
+      "title": "Advanced Settings",
+      "description": "Don't change these, unless you understand what you're doing.",
+      "items": [
+        "ignore_errors",
+        "allow_debug"
+      ]
+    }
+  ],
+  "display": null
+}

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class AladdinConnectGarageDoorOpener {
     this.deviceNumber = config.device_number || 0;
     this.garageNumber = config.garage_number || 1;
     this.ignoreErrors = config.ignore_errors || false;
+    this.allowDebug = config.allow_debug || false;
   }
 
   getServices () {
@@ -90,7 +91,11 @@ class AladdinConnectGarageDoorOpener {
           );
         }
        callback(null);
-     });
+     },
+     accessory.deviceNumber,
+     accessory.garageNumber,
+     accessory.allowDebug
+    );
   }
 
   getState(callback) {
@@ -106,8 +111,9 @@ class AladdinConnectGarageDoorOpener {
             accessory.pollState();
         }
       }, 
-      accessory.deviceNumber, 
-      accessory.garageNumber
+      accessory.deviceNumber,
+      accessory.garageNumber,
+      accessory.allowDebug
     );
   }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class AladdinConnectGarageDoorOpener {
     this.deviceNumber = config.device_number || 0;
     this.garageNumber = config.garage_number || 1;
     this.ignoreErrors = config.ignore_errors || false;
+    this.logPolling = config.log_polling || false;
     this.allowDebug = config.allow_debug || false;
   }
 
@@ -105,7 +106,9 @@ class AladdinConnectGarageDoorOpener {
       'status', 
       function (state) {
         var currentState = accessory.ignoreErrors && state === 'STOPPED' ? 'CLOSED' : state;
-        accessory.log('State of ' + accessory.name + ' is: ' + state + ' (sent ' + currentState + ')');
+        if (accessory.logPolling || state !== currentState) {
+          accessory.log('State of ' + accessory.name + ' is: ' + state + ' (sent ' + currentState + ')');
+        }
         callback(null, Characteristic.CurrentDoorState[currentState], 'getState');
         if (accessory.pollStateDelay > 0) {
             accessory.pollState();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-aladdin-connect-garage-door",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Garage Door Opener plugin for Genie Aladdin Connect",
   "author": {
     "name": "Anatoly Ivanov"
@@ -30,7 +30,7 @@
     "homebridge": ">=0.3.0"
   },
   "dependencies": {
-    "node-aladdin-connect-garage-door": ">=0.0.4"
+    "node-aladdin-connect-garage-door": ">=0.0.9"
   },
   "devDependencies": {},
   "scripts": {}


### PR DESCRIPTION
fixes #2 
This adds the following:

- Version 0.0.6 changes (same as #3, so I closed it)
- `config.schema.json` - Config file for https://github.com/oznu/homebridge-config-ui-x
- `log_polling` option allows user to disable the log that happens when garage status is polled

Please merge as soon as possible.
Also, I want to ask, would it be possible to add me as contributor to this project on GitHub and npmjs.com if possible.  I am planning on adding battery % and other things to https://github.com/apexad/node-aladdin-connect-garage-door within the next few months so wanted to add that to this plugin as soon as possible too!